### PR TITLE
Fix bug for high DPI displays

### DIFF
--- a/site/js/graph.js
+++ b/site/js/graph.js
@@ -416,6 +416,10 @@ export class GraphBase {
         // Ensure the display is not affected by the dpr
         this.canvas.style.width = `${width}px`;
         this.canvas.style.height = `${height}px`;
+
+        // Update the logical width
+        this.width = width - this.edges.left - this.edges.right;
+        this.height = height - this.edges.top - this.edges.bottom;
     }
     
     // Clear and draw graph again.
@@ -431,8 +435,6 @@ export class GraphBase {
     // Handle resizing of window.
     on_resize() {
         this.resize_canvas();
-        this.width = this.canvas.width - this.edges.left - this.edges.right;
-        this.height = this.canvas.height - this.edges.top - this.edges.bottom;
         this.setup_league_styles();
         
         if (this.initialized) this.redraw();


### PR DESCRIPTION
Fix a rendering bug by taking the DPR into account when computing the
logical size of the canvas.  The canvas element's width property is
scaled up by the device pixel ratio (DPR), so it can't be relied upon to
compute the logical size.

Below are the image previews.

### High DPI (current behaviour)

<img width="1199" alt="High-DPI Bug" src="https://user-images.githubusercontent.com/2180969/90317064-c5caa500-def4-11ea-8776-b492aa7c6a2c.png">

### High DPI (with fix applied)

<img width="1199" alt="High-DPI Fixed" src="https://user-images.githubusercontent.com/2180969/90317070-d1b66700-def4-11ea-9e59-3227d553b2bc.png">

### Normal DPI (unaffected)

<img width="1155" alt="Normal DPI" src="https://user-images.githubusercontent.com/2180969/90317075-d844de80-def4-11ea-9401-c4e0b84ce915.png">
