### PR TITLE
Fix tooltip positioning for High DPI devices

### DIFF
--- a/site/js/graph.js
+++ b/site/js/graph.js
@@ -119,7 +119,7 @@ export class GraphBase {
         alpha = alpha || 1.0;
         this.ctx.globalAlpha = alpha;
         this.ctx.fillStyle = "#000000";
-        this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
+        this.ctx.fillRect(0, 0, this.fullWidth, this.fullHeight);
         this.ctx.globalAlpha = 1.0;
     }
     
@@ -336,8 +336,8 @@ export class GraphBase {
         if (this.crosshair) {
             const x = Math.round(this.crosshair.x + this.edges.left) + 0.5;
             const y = Math.round(this.crosshair.y + this.edges.top) + 0.5;
-            this.line("#ffffff", 1, [{x: 0, y: y}, {x: this.canvas.width, y: y}]);
-            this.line("#ffffff", 1, [{x: x, y: 0}, {x: x, y: this.canvas.height}]);
+            this.line("#ffffff", 1, [{x: 0, y: y}, {x: this.fullWidth, y: y}]);
+            this.line("#ffffff", 1, [{x: x, y: 0}, {x: x, y: this.fullHeight}]);
         }
     }
     
@@ -345,7 +345,7 @@ export class GraphBase {
     mouse_on(x, y, m) {
         const width = this.update_tooltip(m) || 210;
         this.tooltip.style.display = "block";
-        const absolute_x = this.canvas.offsetLeft + Math.min(x + this.edges.left + 20, this.canvas.width - width - 10);
+        const absolute_x = this.canvas.offsetLeft + Math.min(x + this.edges.left + 20, this.fullWidth - width - 10);
         const absolute_y = this.canvas.offsetTop + y + this.edges.top + 20;
         this.tooltip.style.left = `${absolute_x}px`;
         this.tooltip.style.top = `${absolute_y}px`;
@@ -418,6 +418,8 @@ export class GraphBase {
         this.canvas.style.height = `${height}px`;
 
         // Update the logical width
+        this.fullWidth = width;
+        this.fullHeight = height;
         this.width = width - this.edges.left - this.edges.right;
         this.height = height - this.edges.top - this.edges.bottom;
     }

--- a/site/js/team.js
+++ b/site/js/team.js
@@ -333,8 +333,8 @@ export class RankingGraph extends GraphBase {
             }
             
             // Clear the area outside the graph.
-            let c_width = this.canvas.width;
-            let c_height = this.canvas.height;
+            let c_width = this.fullWidth;
+            let c_height = this.fullHeight;
             this.area('#000000', [{x: 0, y: 0}, {x: c_width, y: 0}, {x: c_width, y: this.edges.top}, {x: 0, y: this.edges.top}]);
             this.area('#000000', [{x: 0, y: this.edges.top + this.height}, {x: c_width, y: this.edges.top + this.height}, {x: c_width, y: c_height}, {x: 0, y: c_height}]);
         }


### PR DESCRIPTION
This is a follow on to commit 85b68843e9d0bfc7417b890f9e3b069e5ed80153.
`this.canvas.width` (and `this.canvas.height`) can't be used for any
sizing/positioning calculations since the canvas is scaled by the device
pixel ratio.

Use `this.width` (and `this.height`) instead, as these correspond to the
logical size of the canvas. Additionally introduce `this.fullWidth` (and
`this.fullHeight`) for convenience: these include the dimensions of the
edges.

## High DPI Before Fix

<img width="1392" alt="High DPI Before Fix" src="https://user-images.githubusercontent.com/2180969/90968064-1d997b00-e4b6-11ea-8bcf-8b0f93ae1ede.png">

## High DPI After Fix

<img width="1392" alt="High DPI After Fix" src="https://user-images.githubusercontent.com/2180969/90968069-27bb7980-e4b6-11ea-8a69-88085ba5d111.png">

## Normal DPI (for comparison)

<img width="1392" alt="Normal DPI" src="https://user-images.githubusercontent.com/2180969/90968072-2be79700-e4b6-11ea-89f6-3f726f961067.png">
